### PR TITLE
list_instances_by_tag_value should return a list of instance ids

### DIFF
--- a/build.py
+++ b/build.py
@@ -50,7 +50,7 @@ BUILD_DEPENDENCIES = [
 @init
 def set_properties(project, logger):
 
-    project.version = "0.0.9"
+    project.version = "0.0.10"
 
     # Set project dependencies
     for dependency in RUNTIME_DEPENDENCIES:

--- a/src/main/python/configAWSEnv/config_ec2_env.py
+++ b/src/main/python/configAWSEnv/config_ec2_env.py
@@ -38,7 +38,7 @@ class Config:
         elif action == SHUTDOWN:
             filters.append({'Name': 'instance-state-name', 'Values': ['{}'.format('running')]})
 
-        return self.get_ec2_instances(filters)
+        return [instance["InstanceId"] for instance in self.get_ec2_instances(filters)]
 
     def configure_environment(self, action, environment):
         ec2_con = Connections()


### PR DESCRIPTION
- Bug fix: list_instances_by_tag_value should return a list of instance ids instead of the actual EC2 instances.

- Bump version to 0.0.10